### PR TITLE
修改轮播图组件样式

### DIFF
--- a/src/components/home/banner/banner.vue
+++ b/src/components/home/banner/banner.vue
@@ -159,8 +159,6 @@ onMounted(() => {
 	position: absolute;
 	top: calc(50% - 15px);
 	left: 90%;
-	width: 30px;
-	height: 30px;
 	z-index: 3;
 	color: #fff;
 	opacity: 0.6;
@@ -173,7 +171,7 @@ onMounted(() => {
 	position: absolute;
 	width: 30px;
 	height: 30px;
-	z-index: 9;
+	z-index: 8;
 	top: calc(50% - 15px);
 	left: 100%;
 }


### PR DESCRIPTION
1. 看板娘图标没有被顶部导航栏遮挡的bug

> z-index修改为8

2. 切换按钮长宽比例不正确

> prevImg的样式被icon-wrap覆盖，删除了prevImg中width和height的样式