### PR TITLE
修复轮播图顺序错误的bug

### DIFF
--- a/src/components/home/banner/banner.vue
+++ b/src/components/home/banner/banner.vue
@@ -58,10 +58,10 @@ const getBannerList = async () => {
 	if (data.length <= 6) {
 		list = data;
 	} else {
-		// 选取列表中最后三项，以及在其它项中随机选取三项
-		let set = new Set([data.length - 1, data.length - 2, data.length - 3]);
+		// 选取列表中前三项，以及在其它项中随机选取三项
+		let set = new Set([0, 1, 2]);
 		while (set.size < 6) {
-			set.add(getRandom(0, data.length - 4));
+			set.add(getRandom(3, data.length));
 		}
 		set.forEach((value) => {
 			list.push(data[value]);

--- a/src/components/home/banner/banner.vue
+++ b/src/components/home/banner/banner.vue
@@ -61,7 +61,7 @@ const getBannerList = async () => {
 		// 选取列表中前三项，以及在其它项中随机选取三项
 		let set = new Set([0, 1, 2]);
 		while (set.size < 6) {
-			set.add(getRandom(3, data.length));
+			set.add(getRandom(3, data.length-1));
 		}
 		set.forEach((value) => {
 			list.push(data[value]);


### PR DESCRIPTION
轮播图的权重越高，展示越靠前

后端按权重逆序返回数据，应选取列表中前三项，以及在其它项中随机选取三项